### PR TITLE
Parametrize test for help CLI flags

### DIFF
--- a/test_main.py
+++ b/test_main.py
@@ -43,12 +43,12 @@ def py(monkeypatch):
     yield call_py
 
 
-def test_help(py):
-    for flag in ["--help", "-h"]:
-        call = py(flag)
-        assert not call.returncode
-        assert os.fspath(py.path) in call.stdout
-        assert sys.executable in call.stdout
+@pytest.mark.parametrize("flag", ["--help", "-h"])
+def test_help(py, flag):
+    call = py(flag)
+    assert not call.returncode
+    assert os.fspath(py.path) in call.stdout
+    assert sys.executable in call.stdout
 
 
 def test_list(py):


### PR DESCRIPTION
Hi @brettcannon! 👋 

This pull-request updates the test for help CLI flags to be parametrized. Currently if the test fails for `"--help"`, it will not test for `"-h"`. 

https://docs.pytest.org/en/latest/parametrize.html