### PR TITLE
Make the py test fixture more robust

### DIFF
--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -21,14 +21,19 @@ def py(monkeypatch, tmp_path):
     The function has a 'path' attribute for a pathlib.Path object pointing
     at where the Python launcher is located.
 
+    The function has a 'python_executable' attribute for a pathlib.Path
+    object pointing to a temporary symlink to the virtual environments'
+    python executable.
+
     The critical environment variables which can influence the execution of
     the Python launcher are set to a known good state. This includes setting
-    PATH to a single directory of where the Python interpreter executing this
-    file is located.
+    PATH to a single directory in which we create a symlink named with major
+    and minor versions in the name.
     """
     symlink_name = f"python{sys.version_info.major}.{sys.version_info.minor}"
     python_executable = tmp_path / symlink_name
     os.symlink(sys.executable, python_executable)
+
     monkeypatch.delenv("PYLAUNCH_DEBUG", raising=False)
     monkeypatch.setenv("PATH", os.fspath(tmp_path))
     monkeypatch.delenv("VIRTUAL_ENV", raising=False)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -45,7 +45,6 @@ def py(monkeypatch, tmp_path):
         env = os.environ.copy()
         if debug:
             env["PYLAUNCH_DEBUG"] = "1"
-        print(call, env)
         return subprocess.run(call, capture_output=True, text=True, env=env)
 
     call_py.path = py_path


### PR DESCRIPTION
The tests fail for me when running with a fresh clone using doit with python 3.8 on os x.

Depending on how the test virtual environment is created, there is not always a symlink with the python<major>.<minor> naming convention. python -m venv creates only python & python3. Using virtualenv to manually create a virtual environment creates python3.8 symlink and the tests run fine.

This fix modifies the py test fixture so that it creates its own symlink in a temp directory. Then uses that temp directory as the modified PATH passed to the py launcher environment when the test runs.