### PR TITLE
Exclude files only useful for development from published crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,16 @@ version = "1.0.0"
 authors = ["Brett Cannon <brett@python.org>"]
 repository = "https://github.com/brettcannon/python-launcher"
 readme = "README.md"
+include = [
+    "/src/",
+    "/tests/",
+    "/completions/",
+    "/docs/control-flow/control_flow.svg",
+    "/docs/man-page/py.1",
+    "/README.md",
+    "/CHANGELOG.md",
+    "/LICENSE",
+]
 license = "MIT"
 keywords = ["Python"]
 categories = ["command-line-utilities"]

--- a/changelog.d/20210909_120400_decathorpe.md
+++ b/changelog.d/20210909_120400_decathorpe.md
@@ -1,0 +1,41 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+<!--
+### Removed
+
+- A bullet item for the Removed category.
+
+-->
+<!--
+### Added
+
+- A bullet item for the Added category.
+
+-->
+
+### Changed
+
+- Only include necessary files in published crates, reducing the download size for compressed crates by ~60%.
+
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category.
+
+-->
+<!--
+### Fixed
+
+- A bullet item for the Fixed category.
+
+-->
+<!--
+### Security
+
+- A bullet item for the Security category.
+
+-->


### PR DESCRIPTION
This came up while packaging py / python-launcher for Fedora Linux.

The crates published to crates.io contain a few files that look like they're only ever useful for upstream development or your release process, and so they can be excluded from published crates (making upload / download sizes smaller, etc.).

- `/changelog.d`: changelog entry fragments, only used for your release process
- `/docs/readme/`: readme file template, only used during development (?)
- `/release/`: collection of python files / scripts to handle release process
- `/dodo.py`: not sure what this is, but looks like it's used solely for release process purposes

This PR introduces an explicit list of files to be included in published crates:

- `Cargo.toml` is always implicitly included
- `/src/`, `/tests/`, (essential metadata and source code)
- `README.md` and `CHANGELOG.md` (documentation that's useful for "end users")
- shell completions
- the control flow diagram referenced from the `README.md` file, and the manual page for `py.1`
- the LICENSE file

This change has the nice benefit of making the compressed crate ~60% smaller (32 KB vs. 100 KB).