### PR TITLE
Use variadic join function in justfile to clean up globals

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -23,7 +23,8 @@
     "vadimcn.vscode-lldb",
     "matklad.rust-analyzer",
     "tamasfe.even-better-toml",
-    "serayuzgur.crates"
+    "serayuzgur.crates",
+    "skellock.just"
   ],
   // Use 'forwardPorts' to make a list of ports inside the container available locally.
   // "forwardPorts": [],

--- a/changelog.d/20211108_201925_tomfleet2018.md
+++ b/changelog.d/20211108_201925_tomfleet2018.md
@@ -1,0 +1,42 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+<!--
+### Removed
+
+- A bullet item for the Removed category.
+
+-->
+<!--
+### Added
+
+- A bullet item for the Added category.
+
+-->
+
+### Changed
+
+- Tidy up `justfile` global variables with variadic `join` function
+- Include `skellock.just` VSCode extension in devcontainer
+
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category.
+
+-->
+<!--
+### Fixed
+
+- A bullet item for the Fixed category.
+
+-->
+<!--
+### Security
+
+- A bullet item for the Security category.
+
+-->

--- a/justfile
+++ b/justfile
@@ -1,20 +1,14 @@
 #!/usr/bin/env just --justfile
-# Written for https://github.com/casey/just/tree/0.10.2 .
+# Written for https://github.com/casey/just/tree/0.10.3 .
 
 ROOT := justfile_directory()
-DOCS := join(ROOT, "docs")
-MAN_DIR := join(DOCS, "man-page")
-MAN_MD := join(MAN_DIR, "py.1.md")
-MAN_FILE := join(MAN_DIR, "py.1")
+MAN_MD := join(ROOT, "docs", "man-page", "py.1.md")
+MAN_FILE := join(ROOT, "docs", "man-page", "py.1")
 CARGO_TOML := join(ROOT, "Cargo.toml")
-DOT_DIR := join(DOCS, "control-flow")
-DOT_FILE := join(DOT_DIR, "control_flow.dot")
+DOT_FILE := join(ROOT, "docs", "control-flow", "control_flow.dot")
 DOT_FILE_NO_STEM := without_extension(DOT_FILE)
 DOT_SVG := DOT_FILE_NO_STEM + ".svg"
 DOT_PNG := DOT_FILE_NO_STEM + ".png"
-
-# TODO: `just` release after 0.10.2 will make `join` accept variadic parameters;
-# would clean up the variables quite a bit.
 
 # Set default recipes
 _default: lint test man dot


### PR DESCRIPTION
Related to what we discussed during #160.

`just` version [0.10.3](https://github.com/casey/just/blob/master/CHANGELOG.md) made the `join` function accept variadic parameters, this means I could cut down a few of the intermediate global variables I introduced in the referenced PR.

I've also added the `skellock.just` VSCode extension to the devcontainer as it provides nicer syntax highlighting and some other handy stuff for the `justfile` 🙂