### PR TITLE
Skip doc publishing on forks

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -12,6 +12,9 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    # Don't run on forks as they lack access to the Cloudflare token.
+    # (Dependabot is run as if it's a fork, so ignore that, too.)
+    if: github.repository == "brettcannon/python-launcher" && github.actor != "dependabot[bot]"
     permissions:
       contents: read
       deployments: write

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     # Don't run on forks as they lack access to the Cloudflare token.
     # (Dependabot is run as if it's a fork, so ignore that, too.)
-    if: github.repository == "brettcannon/python-launcher" && github.actor != "dependabot[bot]"
+    if: github.repository == 'brettcannon/python-launcher' && github.actor != 'dependabot[bot]'
     permissions:
       contents: read
       deployments: write


### PR DESCRIPTION
This includes Dependabot which is run with the permissions of a fork.