### PR TITLE
Update Cargo.toml to set minimum Rust to 1.66

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ license = "MIT"
 keywords = ["Python"]
 categories = ["command-line-utilities"]
 edition = "2021"
-rust-version = "1.58"
+rust-version = "1.66"
 
 [badges]
 maintenance = { status = "actively-developed" }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -232,7 +232,7 @@ fn venv_path_search() -> Option<PathBuf> {
             let printable_venv_path = venv_path.display();
             log::info!("Checking {printable_venv_path}");
             // bool::then_some() makes more sense, but still experimental.
-            venv_path.is_file().then(|| venv_path)
+            venv_path.is_file().then_some(venv_path)
         })
     }
 }


### PR DESCRIPTION
Fixes a Clippy warning.